### PR TITLE
fix:找不到模块“./index.module.scss”。ts(2307)

### DIFF
--- a/scaffolds/scaffold-simple/src/global.d.ts
+++ b/scaffolds/scaffold-simple/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.scss" {
+  const content: { [className: string]: string };
+  export = content;
+}


### PR DESCRIPTION
ts模板中 `*.scss` 文件以`import styles from './index.module.scss';` 的方式引入的时候会提示找不到模块，加一个`global.d.ts`文件的体验会好一些