### PR TITLE
fix: replace non-existent scss variable

### DIFF
--- a/scaffolds/scaffold-lite-js/src/pages/Dashboard/components/Guide/index.module.css
+++ b/scaffolds/scaffold-lite-js/src/pages/Dashboard/components/Guide/index.module.css
@@ -2,7 +2,7 @@
   min-height: 600px;
   overflow: hidden;
   text-align: center;
-  background-color: $color-white;
+  background-color: #fff;
 }
 
 .title {

--- a/scaffolds/scaffold-lite/src/pages/Dashboard/components/Guide/index.module.css
+++ b/scaffolds/scaffold-lite/src/pages/Dashboard/components/Guide/index.module.css
@@ -2,7 +2,7 @@
   min-height: 600px;
   overflow: hidden;
   text-align: center;
-  background-color: $color-white;
+  background-color: #fff;
 }
 
 .title {


### PR DESCRIPTION
在尝试用脚手架create-ice初始化项目时，使用模板项目发现代码中有两个已经不再使用的scss变量